### PR TITLE
[CLOUD-6594] Add support for both .NET Core SDK (2.1 and 3.1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ LABEL maintainer="Emerald Squad"
 LABEL github="https://github.com/emerald-squad/sonar-scanner-net"
 
 ENV SONAR_SCANNER_MSBUILD_VERSION=4.8.0.12008 \
-    DOTNET_SDK_VERSION=3.1 \
+    DOTNET_2_SDK_VERSION=2.1 \
+    DOTNET_3_SDK_VERSION=3.1 \
     SONAR_SCANNER_MSBUILD_HOME=/opt/sonar-scanner-msbuild \
     DOTNET_PROJECT_DIR=/project \
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true \
@@ -20,7 +21,8 @@ RUN set -x \
   && mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/ \
   && sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/debian/9/prod stretch main" > /etc/apt/sources.list.d/microsoft-prod.list' \
   && apt-get update \
-  && apt-get install dotnet-sdk-$DOTNET_SDK_VERSION -y \
+  && apt-get install dotnet-sdk-$DOTNET_2_SDK_VERSION -y \
+  && apt-get install dotnet-sdk-$DOTNET_3_SDK_VERSION -y \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
That will handle all scenario. Some applications need .NET Core 2.1 to be able to compile or run.